### PR TITLE
Only set gamepad directions for the 1st & 2nd axes

### DIFF
--- a/src/Input/Input.cpp
+++ b/src/Input/Input.cpp
@@ -80,17 +80,19 @@ struct Gosu::Input::Impl
             for (int axis = 0; axis < axes; ++axis) {
                 Sint16 value = SDL_JoystickGetAxis(joysticks[i], axis);
 
-                if (value < -(1 << 14)) {
-                    if (axis % 2 == 0)
-                        currentGamepad[gpLeft - gpRangeBegin] = true;
-                    else
-                        currentGamepad[gpUp - gpRangeBegin] = true;
-                }
-                else if (value > +(1 << 14)) {
-                    if (axis % 2 == 0)
-                        currentGamepad[gpRight - gpRangeBegin] = true;
-                    else
-                        currentGamepad[gpDown - gpRangeBegin] = true;
+                if (axis == 0 || axis == 1) {
+                    if (value < -(1 << 14) && ) {
+                        if (axis % 2 == 0)
+                            currentGamepad[gpLeft - gpRangeBegin] = true;
+                        else
+                            currentGamepad[gpUp - gpRangeBegin] = true;
+                    }
+                    else if (value > +(1 << 14)) {
+                        if (axis % 2 == 0)
+                            currentGamepad[gpRight - gpRangeBegin] = true;
+                        else
+                            currentGamepad[gpDown - gpRangeBegin] = true;
+                    }
                 }
             }
             


### PR DESCRIPTION
I did not build or test this locally yet, but I will give that a shot. I thought it might be useful to try and code what I was thinking the solution might be.

In the scenario where there are more than 2 axes (for examples, left and right triggers), only use the first and second axes for determining the left, right, up, and down gamepad directions.

Closes #261.